### PR TITLE
Fixes RT#90677 Moose enum warnings

### DIFF
--- a/lib/App/Mimosa/Database.pm
+++ b/lib/App/Mimosa/Database.pm
@@ -12,7 +12,7 @@ use Bio::BLAST::Database;
 #use Carp::Always;
 
 # TODO: store this in a shared place, because App::Mimosa::Job has it too
-enum 'Alphabet' => qw(protein nucleotide);
+enum 'Alphabet' => [qw(protein nucleotide)];
 
 has alphabet => (
     isa     => 'Alphabet',

--- a/lib/App/Mimosa/Job.pm
+++ b/lib/App/Mimosa/Job.pm
@@ -61,9 +61,9 @@ has matrix => (
     default => 'BLOSUM62',
 );
 
-enum 'BoolStr' => qw(T F);
+enum 'BoolStr' => [qw(T F)];
 
-enum 'Alphabet' => qw(protein nucleotide);
+enum 'Alphabet' => [qw(protein nucleotide)];
 
 has alphabet => (
     isa     => 'Alphabet',


### PR DESCRIPTION
Fixes https://rt.cpan.org/Ticket/Display.html?id=90677

The new Moose update change the way enum should be called and calling it the old way generates warnings.
